### PR TITLE
Revise rejseplanen integration documentation

### DIFF
--- a/source/_integrations/rejseplanen.markdown
+++ b/source/_integrations/rejseplanen.markdown
@@ -15,132 +15,82 @@ related:
 ha_quality_scale: legacy
 ---
 
-The `rejseplanen` {% term integration %} will provide you with travel details for Danish public transport, using timetable data from [Rejseplanen](https://www.rejseplanen.dk/).
+The `rejseplanen` {% term integration %} will provide you with travel details for Danish public transport, using multidepartureborad data from [Rejseplanen](https://www.rejseplanen.dk/). 
+ou will ahve to setup the central entity that contains the API key and then subsequent sub-entries for each stop/station you want to see. The API will be called from the central entity, ensuring the limit ot the free access is not breached.
+All setup for this integration is done in UI configuration.
 
-## Configuration
+## Prerequisites
+In order to use the integration you must uptain an API key from Rejseplanen.dk. You can apply for this by using the [request form](https://labs.rejseplanen.dk/hc/da/requests/new) on their webpage. Follow the steps for the application and remember to request it as a provate user.
+Keep in mind, the private API key allows for 50.000 calls/month. 
 
-Add a sensor to your {% term "`configuration.yaml`" %} file.
-{% include integrations/restart_ha_after_config_inclusion.md %}
-
-```yaml
-# Example configuration.yaml entry
-sensor:
-  - platform: rejseplanen
-    stop_id: "YOUR_STOP_ID"
-```
-
-{% configuration %}
-stop_id:
-  description: The ID of the public transport stop.
-  required: true
-  type: string
-name:
-  description: "The name of the sensor. Entity ID for the sensor will be created based on this name. E.g., Glostrup St becomes `sensor.glostrup_st`. It's optional but recommended if you define more than one sensor."
-  required: false
-  type: string
-  default: "Next departure"
-route:
-  description: List of route names.
-  required: false
-  type: [string, list]
-direction:
-  description: List of directions to filter by.
-  required: false
-  type: [string, list]
-departure_type:
-  description: List of departure types to filter by.
-  required: false
-  type: [string, list]
-{% endconfiguration %}
 
 ## stop_id
 
-The `stop_id` can be obtained through the following steps:
+The stop id is used in the sub entry config flow know as "stop". The integration will not get data if there are no stop defined in the config.
+Stop ID's can be obtained using multiple methods. The methods described here are based on text search or coordinate search. Both need the API key provided by Rejseplanen.
+
+### By string search
+The stop_id can be found from searching for the city or general area from which you would like to obtain the stop id number.
+- open a webbrowser.
+- fill in the URL with appropriate data such as API key and stop name e.g. Roskilde [https://www.rejseplanen.dk/api/location.name?input=<search_string>&accessId=<YOUR_API_KEY>](https://www.rejseplanen.dk/api/location.name?input=input=<search_string>&accessId=<YOUR_API_KEY>)
+- Look for the "extid" parameter in the response.
+
+The response will look something like this
+```xml
+<LocationList xmlns="http://hacon.de/hafas/proxy/hafas-proxy" serverVersion="2.49.1" dialectVersion="2.45-Rejseplanen" requestId="r2gm7s2iiist82wg">
+  <TechnicalMessages>
+  <TechnicalMessage key="requestTime">2025-06-16 11:53:58</TechnicalMessage>
+  <TechnicalMessage key="backendInfo">ttp=16601#16676 plancode0=72z27 planid=1749820065 planid0=1749820065 planid_adr=1746438686 plancode_adr=52iz0 planid_poi=1746518115 plancode_poi=538ad srvv=5.45.Rejseplanen.17.3.12 (customer/hcudk/release/2025.2.0.3) [2025-04-21] tlibv=TRFVER: rel/dk/11.00.8 2025-02-10 16:37:34 +0100 Rejsekort v11.0.8 jno=1</TechnicalMessage>
+  </TechnicalMessages>
+  <StopLocation id="A=1@O=Roskilde St.@X=12088550@Y=55639093@U=86@L=8600617@B=1@p=1749820065@" extId="8600617" isMainMast="true" name="Roskilde St." lon="12.08855" lat="55.639093" weight="22212" products="239" minimumChangeDuration="PT5M">
+    ...
+  </StopLocation>
+  ...
+</LocationList>
+```
+
+### By coordinates
 
 - Go to [https://www.openstreetmap.org](https://www.openstreetmap.org)
 - Make a search and fill in the location you want to find for.
 - The URL will look like this [https://www.openstreetmap.org/#map=18/56.15756/10.20674](https://www.openstreetmap.org/#map=18/56.15756/10.20674)
-- Now insert the coordinates for the location in the URL, in this example it will be: [http://xmlopen.rejseplanen.dk/bin/rest.exe/stopsNearby?coordX=56.15756&coordY=10.20674&](http://xmlopen.rejseplanen.dk/bin/rest.exe/stopsNearby?coordX=56.15756&coordY=10.20674&)
-- You will now see the 30 stops closest to your location.
-
+- Now insert the coordinates for the location in the URL, in this example it will be: [https://www.rejseplanen.dk/api/location.nearbystops?originCoordLong=12.088367&originCoordLat=55.637912&maxNo=5&accessId=<YOUR_API_KEY>](https://www.rejseplanen.dk/api/location.nearbystops?originCoordLong=12.088367&originCoordLat=55.637912&maxNo=5&accessId=<YOUR_API_KEY>)
+- You will now see the 5 stops closest to your input location.
+  
 You will see an output like this:
 
-```text
-"StopLocation":[{
-    "name":"Engdalsvej/Århusvej (Favrskov Kom)",
-    "x":"10078598",
-    "y":"56243456",
-    "id":"713000702"
+```xml
+<LocationList xmlns="http://hacon.de/hafas/proxy/hafas-proxy" serverVersion="2.49.1" dialectVersion="2.45-Rejseplanen" requestId="m54u7sm8gq4pww8x">
+  <TechnicalMessages>
+  <TechnicalMessage key="requestTime">2025-06-16 12:28:27</TechnicalMessage>
+  <TechnicalMessage key="backendInfo">ttp=16601#16676 plancode0=72z27 planid=1749820065 planid0=1749820065 planid_adr=1746438686 plancode_adr=52iz0 planid_poi=1746518115 plancode_poi=538ad srvv=5.45.Rejseplanen.17.3.12 (customer/hcudk/release/2025.2.0.3) [2025-04-21] tlibv=TRFVER: rel/dk/11.00.8 2025-02-10 16:37:34 +0100 Rejsekort v11.0.8 jno=1</TechnicalMessage>
+  </TechnicalMessages>
+  <StopLocation id="A=1@O=Roskilde St. (togbus)@X=12088388@Y=55637826@U=86@L=8651617@" extId="8651617" name="Roskilde St. (togbus)" lon="12.088388" lat="55.637826" weight="1563" dist="10" products="8" minimumChangeDuration="PT5M">
+    ...
+  </StopLocation>
+  <StopLocation id="A=1@O=Roskilde St. (togbus)@X=12088334@Y=55637799@U=86@L=8650617@" extId="8650617" name="Roskilde St. (togbus)" lon="12.088334" lat="55.637799" weight="1563" dist="13" products="8" minimumChangeDuration="PT5M">
+    ...
+  </StopLocation>
+</LocationList>
 ```
 
-Find the name of your stop in the list and the "id" is the one you are looking for to us as value for `stop_id:`.
-
-## Direction
-
-If you use the `direction` filter it's important to put correct final destination(s) or else the sensor will not work at all.
-The `direction` has to be the scheduled final destination (direction) for the `Departure type` - ***NOT the stop where you want to get off***.
-
-- Replace YOUR_STOP_ID with the id for your stop and go to [http://xmlopen.rejseplanen.dk/bin/rest.exe/departureBoard?id=YOUR_STOP_ID](http://xmlopen.rejseplanen.dk/bin/rest.exe/departureBoard?id=YOUR_STOP_ID)
-- The values under `direction` is the ones you need to put under `direction`. Make sure you use the exact name, and add all that apply.
-
-You will see an output like this:
-
-```text
-<Departure name="Bus 200" type="BUS" stop="Engdalsvej/Århusvej (Favrskov Kom)" time="10:15" date="06.05.20" id="713000701" line="200" messages="0" finalStop="Bjergegårdsvej/Rylevej (Favrskov Kom)" direction="Hinnerup">
-<JourneyDetailRef ref="http://xmlopen.rejseplanen.dk/bin/rest.exe/journeyDetail?ref=248868%2F117643%2F641354%2F237721%2F86%3Fdate%3D06.05.20" />
-</Departure>
-<Departure name="Bus 200" type="BUS" stop="Engdalsvej/Århusvej (Favrskov Kom)" time="10:25" date="06.05.20" id="713000702" line="200" messages="0" finalStop="Skanderborg Busterminal (Skanderborg Kom)" direction="Skanderborg Busterminal (Skanderborg Kom)">
-<JourneyDetailRef ref="http://xmlopen.rejseplanen.dk/bin/rest.exe/journeyDetail?ref=512592%2F205637%2F693742%2F176008%2F86%3Fdate%3D06.05.20" />
-</Departure>
-```
-
-A working example on how to use this sensor with direction:
-
-```yaml
-# Example configuration.yaml entry with the correct use of direction.
-sensor:
-  - platform: rejseplanen
-    stop_id: "713000702"
-    direction:
-      - 'Bjergegårdsvej/Rylevej (Favrskov Kom)'
-      - 'Skanderborg Busterminal (Skanderborg Kom)'
-```
-
-## Route
-
-If you use the `route` filter it's important to put correct route name(s) or else the sensor will not work at all. 
-
-- Replace YOUR_STOP_ID with the id for your stop and go to [http://xmlopen.rejseplanen.dk/bin/rest.exe/departureBoard?id=YOUR_STOP_ID](http://xmlopen.rejseplanen.dk/bin/rest.exe/departureBoard?id=YOUR_STOP_ID)
-- The values under `Departure name` is the ones you need to put under `route`. Make sure you use the exact name.
-
-You will see an output like this:
-
-```text
-<Departure name="Bus 1A" type="BUS" stop="Elmegade (Nørrebrogade)" time="10:19" date="06.05.20" id="45739" line="1A" messages="0" rtTime="10:21" rtDate="06.05.20" finalStop="Avedøre St." direction="Avedøre St.">
-<JourneyDetailRef ref="http://xmlopen.rejseplanen.dk/bin/rest.exe/journeyDetail?ref=138234%2F58362%2F751742%2F329795%2F86%3Fdate%3D06.05.20" />
-</Departure>
-<Departure name="Bus 5C" type="BUS" stop="Elmegade (Nørrebrogade)" time="10:22" date="06.05.20" id="45739" line="5C" messages="0" rtTime="10:23" rtDate="06.05.20" finalStop="Husum Torv, Sløjfen (Sløjfen)" direction="Husum Torv">
-<JourneyDetailRef ref="http://xmlopen.rejseplanen.dk/bin/rest.exe/journeyDetail?ref=899547%2F321443%2F654384%2F27343%2F86%3Fdate%3D06.05.20" />
-</Departure>
-```
+Find the name of your stop in the list and the "id" is the parameter marked as extid to be used in the `stop_id:` list.
 
 ## Examples
 
 A more extensive example on how to use this sensor:
 
 ```yaml
-# Example configuration.yaml entry
+# Example configuration.yaml entry with the correct use of authentication.
 sensor:
   - platform: rejseplanen
-    name: "Elmegade 350S"
-    stop_id: "000045740"
-    route: "Bus 350S"
-    direction:
-      - 'Herlev St.'
-      - 'Ballerup St.'
+    name: "Roskilde St."
+    authentication: "YOUR_API_KEY"
+    stop_id:
+      - 860061707
 ```
 
-The sensor can filter the timetables by one or more routes, directions and types. The known types are listed in the table below.
+The sensor can filter the timetables by one or more types. The known types are listed in the table below.
 
 | Departure type | Description             |
 | -------------- | ----------------------- |


### PR DESCRIPTION
## Proposed change
Updated the docs to match the changes to Rejseplanen API and description of how to obtain an API key for use with HA.



## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
The updated docs should be sufficient to use the updated integration, Rejseplanen, where the company chaged their API to require API key for all requests.

- Link to parent pull request in the codebase: #152200
- This PR fixes or closes issue: fixes #133420

## Checklist


- [ x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards